### PR TITLE
upgrade argon2 to 0.28.5

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,7 @@
     "devstart": "nodemon ./bin/www"
   },
   "dependencies": {
-    "argon2": "^0.19.3",
+    "argon2": "^0.28.5",
     "body-parser": "^1.18.3",
     "bootstrap": "^3.4.1",
     "cookie-parser": "~1.4.3",


### PR DESCRIPTION
node-argon2 provides prebuilt binaries from v0.26.0 onwards.